### PR TITLE
Add Support for Teensy 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 artwork/
 test/
 
+# Visual Code + PlatformIO
+.pio
+.vscode
+.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a `platformio.ini` file to aid in the development of this library using hte Platform IO environment. This is only useful for developing this library itself, and not at all used for using this library in your projects.
+- Added support for Teensy 4.x boards
 
 ## [2.0.1]
 ### Added

--- a/examples/10x10-matrix/color_gradient-10x10/color_gradient-10x10.ino
+++ b/examples/10x10-matrix/color_gradient-10x10/color_gradient-10x10.ino
@@ -8,17 +8,14 @@ RGBLEDMatrix leds(10,10);
 void setup() {
 	leds.setup();
 	leds.startDrawing();
-	for (int y = 0; y < leds.rows(); y++ ) {
-		for (int x = 0; x < leds.columns(); x++ ) {
+	for (unsigned int y = 0; y < leds.rows(); y++ ) {
+		for (unsigned int x = 0; x < leds.columns(); x++ ) {
 			float dx = leds.columns() - x - 1;
 			float dy = leds.rows()-y - 1;
-			float dmy = leds.rows()/2.0-y;
 
 			float d_tl = max(1.0-sqrt(x*x + y*y)/MAX_DISTANCE, 0);
-			float d_tr = max(1.0-sqrt(dx*dx + y*y)/MAX_DISTANCE, 0);
 			float d_bl = max(1.0-sqrt(x*x + (leds.rows()-y)*(leds.rows()))/MAX_DISTANCE, 0);
 			float d_br = max(1.0-sqrt(dx*dx + dy*dy)/MAX_DISTANCE, 0);
-			float d_rm = max(1.0-sqrt(dx*dx + dmy*dmy)/(MAX_DISTANCE*3.0/4.0), 0);
 
 			RGBColorType c = RGBColor::fromRGB( d_tl*255, d_br*194, d_bl*255);
 			leds.writePixel(x, y, c);

--- a/examples/10x10-matrix/dot-chaser-10x10/dot-chaser-10x10.ino
+++ b/examples/10x10-matrix/dot-chaser-10x10/dot-chaser-10x10.ino
@@ -8,15 +8,15 @@ private:
   int _xVel;
   int _yVel;
 
-  int _xStack[5] = {-1,-1,-1,-1,-1};
-  int _yStack[5] = {-1,-1,-1,-1,-1};
+  unsigned int _xStack[5] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
+  unsigned int _yStack[5] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
   
   
 protected:
   virtual void action() {
     _screen->startDrawing();
-    for (int x = 0; x < _screen->columns(); ++x) {
-      for (int y = 0; y < _screen->rows(); ++y ) {
+    for (unsigned int x = 0; x < _screen->columns(); ++x) {
+      for (unsigned int y = 0; y < _screen->rows(); ++y ) {
         RGBColorType color = 0;
         if ( x == _xStack[4] && y == _yStack[4] ) {
           color = DARK_BLUE_COLOR;

--- a/examples/16x16-matrix/color_gradient-16x16-cprg/color_gradient-16x16-cprg.ino
+++ b/examples/16x16-matrix/color_gradient-16x16-cprg/color_gradient-16x16-cprg.ino
@@ -8,18 +8,15 @@ RGBLEDMatrix leds(16,16, RGBLEDMatrix::RGB_GROUPS_CPRG8, HIGH, LOW, 3);
 void setup() {
 	leds.setup();
 	leds.startDrawing();
-	for (int y = 0; y < leds.rows(); y++ ) {
-		for (int x = 0; x < leds.columns(); x++ ) {
+	for (unsigned int y = 0; y < leds.rows(); y++ ) {
+		for (unsigned int x = 0; x < leds.columns(); x++ ) {
 			float dx = leds.columns() - x - 1;
 			float dy = leds.rows()-y - 1;
-			float dmy = leds.rows()/2.0-y;
 
 			float d_tl = max(1.0-sqrt(x*x + y*y)/MAX_DISTANCE, 0);
-			float d_tr = max(1.0-sqrt(dx*dx + y*y)/MAX_DISTANCE, 0);
 			float d_bl = max(1.0-sqrt(x*x + (leds.rows()-y)*(leds.rows()))/MAX_DISTANCE, 0);
 			float d_br = max(1.0-sqrt(dx*dx + dy*dy)/MAX_DISTANCE, 0);
-			float d_rm = max(1.0-sqrt(dx*dx + dmy*dmy)/(MAX_DISTANCE*3.0/4.0), 0);
-
+	
 			RGBColorType c = RGBColor::fromRGB( d_tl*255, d_br*194, d_bl*255);
 			leds.writePixel(x, y, c);
 		} 

--- a/examples/16x16-matrix/conway-game-of-life-16x16-cprg/conway-game-of-life-16x16-cprg.ino
+++ b/examples/16x16-matrix/conway-game-of-life-16x16-cprg/conway-game-of-life-16x16-cprg.ino
@@ -83,8 +83,8 @@ void CellUniverse::setCellStatus(unsigned int row, unsigned int column, LifeStat
 
 CellUniverse::LifeState CellUniverse::getCellStatus(int row, int column) const {
   // this causes the matrix to be a toroidal array
-  unsigned int r = row < 0 ? row + _leds.rows() : ( row >= _leds.rows() ? row - _leds.rows() : row );
-  unsigned int c = column < 0 ? column + _leds.columns() : ( column >= _leds.columns() ? column - _leds.columns() : column );
+  unsigned int r = row < 0 ? row + _leds.rows() : ( row >= (int)_leds.rows() ? row - _leds.rows() : row );
+  unsigned int c = column < 0 ? column + _leds.columns() : ( column >= (int)_leds.columns() ? column - _leds.columns() : column );
 
   // double check just to be sure
   if (r >= _leds.rows() || c >= _leds.columns()) {

--- a/examples/16x16-matrix/dot-chaser-16x16-cprg/dot-chaser-16x16-cprg.ino
+++ b/examples/16x16-matrix/dot-chaser-16x16-cprg/dot-chaser-16x16-cprg.ino
@@ -8,15 +8,15 @@ private:
   int _xVel;
   int _yVel;
 
-  int _xStack[5] = {-1,-1,-1,-1,-1};
-  int _yStack[5] = {-1,-1,-1,-1,-1};
+  unsigned int _xStack[5] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
+  unsigned int _yStack[5] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
   
   
 protected:
   virtual void action() {
     _screen->startDrawing();
-    for (int x = 0; x < _screen->rows(); ++x) {
-      for (int y = 0; y < _screen->columns(); ++y ) {
+    for (unsigned int x = 0; x < _screen->rows(); ++x) {
+      for (unsigned int y = 0; y < _screen->columns(); ++y ) {
         RGBColorType color = 0;
         if ( x == _xStack[4] && y == _yStack[4] ) {
           color = DARK_BLUE_COLOR;

--- a/examples/16x16-matrix/plasma-16x16-cprg/plasma-16x16-cprg.ino
+++ b/examples/16x16-matrix/plasma-16x16-cprg/plasma-16x16-cprg.ino
@@ -88,42 +88,35 @@ void setup() {
   leds.startScanning();
 }
 
-unsigned long loopCounter = 0;
 unsigned long timeCount = 0;
 bool timeIncrement = true;
 
-#if (defined(__arm__)&& defined(TEENSYDUINO) || defined(ESP32))
-// slow things down for the Teensy
-const unsigned long loopMod = 10000;
-#else
-const unsigned long loopMod = 50;
-#endif
-
 void loop() {
   leds.loop();
-  loopCounter++;
 
-  if (loopCounter == loopMod) {
-    if (timeIncrement) {
-      timeCount++;
-      
-      //
-      // set a maximum to timeCount because floats only have
-      // a max precision of 5 significant digits. Otherwise, when timeCount
-      // gets too large, the animation will get choppy because calls to drawPlasma()
-      // will not have a noticable change to timeCount/TIME_DILATION. for several
-      // consecutive calls.
-      //
-      if (timeCount >= 1000*PI) {
-        timeIncrement = false;
-      }
-    } else {
-      timeCount--;
-      if (timeCount == 0) {
-        timeIncrement = true;
-      }
+  // update frame every 40 milleseconds. AVR chips are slow enough to not need this delay.
+  #if !defined(ARDUINO_ARCH_AVR)
+  delay(40);
+  #endif
+
+  if (timeIncrement) {
+    timeCount++;
+  
+    //
+    // set a maximum to timeCount because floats only have
+    // a max precision of 5 significant digits. Otherwise, when timeCount
+    // gets too large, the animation will get choppy because calls to drawPlasma()
+    // will not have a noticable change to timeCount/TIME_DILATION. for several
+    // consecutive calls.
+    //
+    if (timeCount >= 1000*PI) {
+      timeIncrement = false;
     }
-    drawPlasma(timeCount);
-    loopCounter = 0;
+  } else {
+    timeCount--;
+    if (timeCount == 0) {
+      timeIncrement = true;
+    }
   }
+  drawPlasma(timeCount);
 }

--- a/examples/8x8-matrix/color_gradient-8x8/color_gradient-8x8.ino
+++ b/examples/8x8-matrix/color_gradient-8x8/color_gradient-8x8.ino
@@ -8,17 +8,14 @@ RGBLEDMatrix leds(8,8);
 void setup() {
 	leds.setup();
 	leds.startDrawing();
-	for (int y = 0; y < leds.rows(); y++ ) {
-		for (int x = 0; x < leds.columns(); x++ ) {
+	for (unsigned int y = 0; y < leds.rows(); y++ ) {
+		for (unsigned int x = 0; x < leds.columns(); x++ ) {
 			float dx = leds.columns() - x - 1;
 			float dy = leds.rows()-y - 1;
-			float dmy = leds.rows()/2.0-y;
 
 			float d_tl = max(1.0-sqrt(x*x + y*y)/MAX_DISTANCE, 0);
-			float d_tr = max(1.0-sqrt(dx*dx + y*y)/MAX_DISTANCE, 0);
 			float d_bl = max(1.0-sqrt(x*x + (leds.rows()-y)*(leds.rows()))/MAX_DISTANCE, 0);
 			float d_br = max(1.0-sqrt(dx*dx + dy*dy)/MAX_DISTANCE, 0);
-			float d_rm = max(1.0-sqrt(dx*dx + dmy*dmy)/(MAX_DISTANCE*3.0/4.0), 0);
 
 			RGBColorType c = RGBColor::fromRGB( d_tl*255, d_br*194, d_bl*255);
 			leds.writePixel(x, y, c);

--- a/examples/8x8-matrix/dot-chaser-8x8/dot-chaser-8x8.ino
+++ b/examples/8x8-matrix/dot-chaser-8x8/dot-chaser-8x8.ino
@@ -8,15 +8,15 @@ private:
   int _xVel;
   int _yVel;
 
-  int _xStack[5] = {-1,-1,-1,-1,-1};
-  int _yStack[5] = {-1,-1,-1,-1,-1};
+  unsigned int _xStack[5] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
+  unsigned int _yStack[5] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
   
   
 protected:
   virtual void action() {
     _screen->startDrawing();
-    for (int x = 0; x < _screen->rows(); ++x) {
-      for (int y = 0; y < _screen->columns(); ++y ) {
+    for (unsigned int x = 0; x < _screen->rows(); ++x) {
+      for (unsigned int y = 0; y < _screen->columns(); ++y ) {
         RGBColorType color = 0;
         if ( x == _xStack[4] && y == _yStack[4] ) {
           color = DARK_BLUE_COLOR;

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,91 @@
+; This PlatformIO onfiguration is for development on this library only, 
+; not for usage of this library in other projects. 
+
+[platformio]
+src_dir = examples/16x16-matrix/plasma-16x16-cprg
+default_envs = teensy40
+lib_dir = .
+
+[common]
+lib_deps = 
+	Adafruit GFX Library
+	SPI
+	Wire
+
+[env:teensy40]
+platform = teensy
+board = teensy40
+framework = arduino
+lib_deps = 
+	TimerThree
+	${common.lib_deps}
+build_flags = -Wno-unknown-pragmas
+
+[env:teensy31]
+platform = teensy
+board = teensy31
+framework = arduino
+lib_deps = 
+	TimerThree
+	${common.lib_deps}
+build_flags = -Wno-unknown-pragmas
+
+[env:esp8266]
+platform = espressif8266
+board = nodemcuv2
+framework = arduino
+lib_deps =
+    ${common.lib_deps}
+
+[env:lolin32]
+platform = espressif32
+board = lolin32
+framework = arduino
+lib_deps =
+    ${common.lib_deps}
+
+[env:MightyCore]
+platform = atmelavr
+board = ATmega1284P
+framework = arduino
+lib_deps =
+    ${common.lib_deps}
+
+; Clock frequency in [Hz]
+board_build.f_cpu = 20000000L
+
+; HARDWARE SETTINGS
+; Oscillator option
+board_hardware.oscillator = external
+; Hardware UART for serial upload
+board_hardware.uart = uart0
+; Brown-out detection
+board_hardware.bod = 2.7v
+; EEPROM retain
+board_hardware.eesave = yes
+
+; UPLOAD SETTINGS
+board_upload.speed = 115200
+; Upload serial port is automatically detected by default. Override by uncommenting the line below
+;upload_port = /dev/cu.usbserial*
+
+; BUILD OPTIONS
+; Current pinout
+board_build.variant = standard
+; Comment out to enable LTO (this line unflags it)
+build_unflags = -flto
+
+; Extra build flags
+build_flags = -Wno-unknown-pragmas
+
+
+; Upload using programmer
+;upload_protocol = usbasp
+; Aditional upload flags
+;upload_flags = -Pusb
+
+; SERIAL MONITOR OPTIONS
+; Monitor and upload port is the same by default
+;monitor_port = 
+; Serial monitor baud rate
+monitor_speed = 9600

--- a/src/RGBAnimation.cpp
+++ b/src/RGBAnimation.cpp
@@ -87,8 +87,6 @@ ColorBitmapSequenceAnimation::ColorBitmapSequenceAnimation(
 }
 
 void ColorBitmapSequenceAnimation::erase(RGBLEDMatrix& matrix) {
-	int idx = this->getSequenceIndex();
-
 	matrix.writeFillRect(
 		this->getOriginX() - _leftPadSize,
 		this->getOriginY() - _topPadSize,

--- a/src/RGBLEDMatrix.cpp
+++ b/src/RGBLEDMatrix.cpp
@@ -91,7 +91,7 @@ bool RGBLEDMatrix::allowedFrameForValue(uint16_t value, size_t frame) const {
 			// green has a bit specific to this pass, on for that.
 			return ( (value&0x0040) != 0 ) ||
 			// only one for red and blue if both the prior pass and next pass are on
-					(value&0x1800 == 0x1800) || (value&0x0003 == 0x0003);
+					((value&0x1800) == 0x1800) || ((value&0x0003) == 0x0003);
 				break;
 		case 2:
 			// red bit 2, green bit 3, blue bit 2


### PR DESCRIPTION
Adds support for Teensy 4.x, as `TimerThree` doesn't work the same on Teensy4.x as it did on Teensy 3.x.

Also migrates library development in the PlatformIO environment. This is only relevant to development on this library itself, and has no impact on using this library with Arduino.

Finally, cleaned up the code in various places, mostly to address compiler warnings. 